### PR TITLE
Update angle_switch.cfg

### DIFF
--- a/Software/Firmware/klipper/options/angle_switch.cfg
+++ b/Software/Firmware/klipper/options/angle_switch.cfg
@@ -46,7 +46,7 @@ gcode:
     
         # Move the nozzle near the bed
         G1 X0 Y0 Z5 F3000
-        PRIME_RIGHT
+        NOZZLE_PRIME
         G0 Z5 F3000
         G21 ; set units to millimeters
         G90 ; use absolute coordinates


### PR DESCRIPTION
Looks like PRIME_RIGHT got removed from the macro list and replaced with NOZZLE_PRIME