### PR TITLE
adjust printer.cfgs

### DIFF
--- a/Software/Firmware/klipper/LDO-printer.cfg
+++ b/Software/Firmware/klipper/LDO-printer.cfg
@@ -55,7 +55,7 @@ enable_pin: !Y_ENABLE
 microsteps: 16
 rotation_distance: 32
 endstop_pin: tmc2209_stepper_y:virtual_endstop
-homing_retract_dist: 10
+homing_retract_dist: 0
 position_min: -7.5
 position_max: 105
 homing_speed: 25
@@ -132,6 +132,10 @@ gcode:
     G0 X50 F2000           # Move to the middle of the bed 
     _SET_HOMING_CURRENT CURRENT=.20
     G28 Y 
+    # Move back a bit away from the hard-stop immediately after homing
+    G91                    # Set to Relative positioning
+    G1 Y10 F2000           # Move Y forward 10mm away from the edge
+    G90                    # Set back to Absolute positioning
     _RESTORE_RUN_CURRENT 
     SET_GCODE_OFFSET Y=-7.5 # Diagnostic, because we seem to be homing and then thinking 7.5mm away is actually 0... so if we tell it we're at 7.5, 0 should be correct right?
     G28 Z    

--- a/Software/Firmware/klipper/printer.cfg
+++ b/Software/Firmware/klipper/printer.cfg
@@ -58,7 +58,7 @@ enable_pin: !Y_ENABLE
 microsteps: 16
 rotation_distance: 32
 endstop_pin: tmc2209_stepper_y:virtual_endstop
-homing_retract_dist: 10
+homing_retract_dist: 0
 position_min: -7.5
 position_max: 105
 homing_speed: 25
@@ -147,6 +147,10 @@ gcode:
   {% if home_all or 'Y' in params %}
     _SET_HOMING_CURRENT CURRENT=.20
     G28 Y 
+    # Move back a bit away from the hard-stop immediately after homing
+    G91             # Set to Relative positioning
+    G1 Y10 F2000     # Move Y forward 5mm away from the edge
+    G90             # Set back to Absolute positioning
     _RESTORE_RUN_CURRENT 
     SET_GCODE_OFFSET Y=0.0 # Start at 0.0 and adjust negative for squish on printer bed
   {% endif %}


### PR DESCRIPTION
setting homing_retract_dist on y to 0 to get rid of "Endstop stepper_y still triggered after retract" errors.  moved the Y +10mm move into the homing macros.  When the printer hits the end of the axis, it registers the stall, stops, and immediately tries to pull away by 10mm. Klipper interprets that sudden acceleration change to back away as a second "crash," throwing the error.